### PR TITLE
Release 1.7.0

### DIFF
--- a/imagemagick-engine.php
+++ b/imagemagick-engine.php
@@ -5,7 +5,7 @@
 	Description: Improve the quality of re-sized images by replacing standard GD library with ImageMagick
 	Author: Orangelab
 	Author URI: https://orangelab.com/
-	Version: 1.6.6
+	Version: 1.7.0
 	Text Domain: imagemagick-engine
 
 	Copyright @ 2021 Orangelab AB
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Constants
  */
 define( 'IME_OPTION_VERSION', 1 );
-define( 'IME_VERSION', '1.6.6' );
+define( 'IME_VERSION', '1.7.0' );
 
 /*
  * Global variables
@@ -644,7 +644,7 @@ function ime_ajax_regeneration_get_images() {
 	}
 
 	// Query for the IDs only to reduce memory usage
-	$images = $wpdb->get_results( "SELECT ID FROM $wpdb->posts WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%'" );
+	$images = $wpdb->get_results( "SELECT ID FROM $wpdb->posts WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%' AND post_mime_type != 'image/svg+xml'" );
 
 	// Generate the list of IDs
 	$ids = [];

--- a/imagemagick-engine.php
+++ b/imagemagick-engine.php
@@ -5,10 +5,10 @@
 	Description: Improve the quality of re-sized images by replacing standard GD library with ImageMagick
 	Author: Orangelab
 	Author URI: https://orangelab.com/
-	Version: 1.6.5
+	Version: 1.6.6
 	Text Domain: imagemagick-engine
 
-	Copyright @ 2020 Orangelab AB
+	Copyright @ 2021 Orangelab AB
 
 	Licenced under the GNU GPL:
 
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Constants
  */
 define( 'IME_OPTION_VERSION', 1 );
-define( 'IME_VERSION', '1.6.5' );
+define( 'IME_VERSION', '1.6.6' );
 
 /*
  * Global variables

--- a/imagemagick-engine.php
+++ b/imagemagick-engine.php
@@ -5,7 +5,7 @@
 	Description: Improve the quality of re-sized images by replacing standard GD library with ImageMagick
 	Author: Orangelab
 	Author URI: https://orangelab.com/
-	Version: 1.6.4
+	Version: 1.6.5
 	Text Domain: imagemagick-engine
 
 	Copyright @ 2020 Orangelab AB
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Constants
  */
 define( 'IME_OPTION_VERSION', 1 );
-define( 'IME_VERSION', '1.6.4' );
+define( 'IME_VERSION', '1.6.5' );
 
 /*
  * Global variables

--- a/readme.txt
+++ b/readme.txt
@@ -19,7 +19,7 @@ Features
 * Configure image quality or use dynamically computed default value
 * Optimize different image sizes for either quality or size
 
-Lnguages: English, French, German, Swedish
+Lnguages: English, French, German, Swedish, Turkish
 
 Requires either ImageMagick binary or Imagick PHP module.
 
@@ -73,6 +73,9 @@ You'll probably have problems with various other plugins too unless you fix this
 1. Administration interface
 
 == Changelog ==
+
+= 1.6.5 =
+* Turkish translation thanks to Haydar ŞAHİN
 
 = 1.6.4 =
 * Critical bugfix for .jpeg files

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: rickardw, orangelab
 Tags: image, images, picture, imagemagick, gd
 Requires at least: 3.0
 Tested up to: 5.8.0
-Stable tag: 1.6.6
+Stable tag: 1.7.0
 
 Improve the quality of re-sized images by replacing standard GD library with ImageMagick.
 
@@ -74,7 +74,9 @@ You'll probably have problems with various other plugins too unless you fix this
 
 == Changelog ==
 
-= 1.6.6 =
+= 1.7.0 =
+* Add option to resize images interlaced
+* Fix: Don't attempt to regenerate SVG's.
 * Handle scaled images with wp_get_original_image_path
 * Bugfix cli executable respnsonse
 * Tested compability with WordPress 5.8

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: rickardw, orangelab
 Tags: image, images, picture, imagemagick, gd
 Requires at least: 3.0
-Tested up to: 5.4.1
-Stable tag: 1.6.4
+Tested up to: 5.5.0
+Stable tag: 1.6.5
 
 Improve the quality of re-sized images by replacing standard GD library with ImageMagick.
 
@@ -76,7 +76,8 @@ You'll probably have problems with various other plugins too unless you fix this
 
 = 1.6.5 =
 * Turkish translation thanks to Haydar ŞAHİN
-* Bugfixes
+* Bugfix
+* Tested compability with WordPress 5.5
 
 = 1.6.4 =
 * Critical bugfix for .jpeg files

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: rickardw, orangelab
 Tags: image, images, picture, imagemagick, gd
 Requires at least: 3.0
-Tested up to: 5.5.0
-Stable tag: 1.6.5
+Tested up to: 5.8.0
+Stable tag: 1.6.6
 
 Improve the quality of re-sized images by replacing standard GD library with ImageMagick.
 
@@ -73,6 +73,11 @@ You'll probably have problems with various other plugins too unless you fix this
 1. Administration interface
 
 == Changelog ==
+
+= 1.6.6 =
+* Handle scaled images with wp_get_original_image_path
+* Bugfix cli executable respnsonse
+* Tested compability with WordPress 5.8
 
 = 1.6.5 =
 * Turkish translation thanks to Haydar ŞAHİN


### PR DESCRIPTION
* Add option to resize images interlaced
* Fix: Don't attempt to regenerate SVG's.
* Handle scaled images with wp_get_original_image_path
* Bugfix cli executable respnsonse
* Tested compability with WordPress 5.8